### PR TITLE
Add https://nosto.re as available gateway to view nsites

### DIFF
--- a/src/lib/tools-resources.yaml
+++ b/src/lib/tools-resources.yaml
@@ -50,7 +50,7 @@ nsiteGateways:
     url: https://nostrdeploy.com
   - name: nosto.re
     desc: ""
-    url: https://nsite.nosto.re
+    url: https://nosto.re
 
 blossomServers:
   - name: Find Blossom Servers


### PR DESCRIPTION
This PR will add https://nosto.re as a gateway to view nsites.

Some examples

https://npub18spj373rueny6uwx4lk8e3g7cw7wjj40ua7llhu7600wqne5qg9s2d9d8c.nosto.re
https://npub1phpdev2d38u5hzs4jrsh360mevh0rjctu9669quy97wu23u8sqdqpfha0j.nosto.re
https://npub1zz6g0z3r2xaqwf4k4u5f6cqsstc0qx9hjxkd5flxaazq3wnx03xqppq4fv.nosto.re

Tagging @dskvr for extra visibilty ;)