### PR TITLE
fix: preserve MIME types in SPA uploads

### DIFF
--- a/apps/spa/package-lock.json
+++ b/apps/spa/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@nsite/spa",
       "version": "0.0.0",
       "dependencies": {
+        "@std/media-types": "npm:@jsr/std__media-types@^1.1.0",
         "applesauce-core": "^5.1.0",
         "applesauce-relay": "^5.1.0",
         "applesauce-signers": "^5.1.0",
@@ -719,9 +720,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,9 +734,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,9 +748,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +762,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -787,9 +776,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -804,9 +790,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,9 +804,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -838,9 +818,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -855,9 +832,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -872,9 +846,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,9 +860,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,9 +874,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -923,9 +888,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,6 +1037,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@std/media-types": {
+      "name": "@jsr/std__media-types",
+      "version": "1.1.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/std__media-types/1.1.0.tgz",
+      "integrity": "sha512-dHvaxHL7ENWnltgL653uo3KnKFse3ZbopZop2gqsT7yrscx7irZEClu5Cba7gMPPRk4Lg1FbriNcaBViM2RSBw=="
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "3.1.2",

--- a/apps/spa/package.json
+++ b/apps/spa/package.json
@@ -10,6 +10,7 @@
     "test": "vitest --run"
   },
   "dependencies": {
+    "@std/media-types": "npm:@jsr/std__media-types@^1.1.0",
     "applesauce-core": "^5.1.0",
     "applesauce-relay": "^5.1.0",
     "applesauce-signers": "^5.1.0",

--- a/apps/spa/src/components/DeployZone.svelte
+++ b/apps/spa/src/components/DeployZone.svelte
@@ -81,7 +81,8 @@
             files.push(...extracted);
           } else {
             const ab = await fileObj.arrayBuffer();
-            files.push({ path: '/' + fileObj.name, data: ab, size: fileObj.size });
+            const path = '/' + fileObj.name;
+            files.push({ path, data: ab, size: fileObj.size, type: fileObj.type || undefined });
           }
         }
       }
@@ -116,10 +117,12 @@
       } else if (entry.isFile) {
         const fileObj = await entryToFile(entry);
         const ab = await fileObj.arrayBuffer();
+        const path = prefix + '/' + entry.name;
         files.push({
-          path: prefix + '/' + entry.name,
+          path,
           data: ab,
           size: fileObj.size,
+          type: fileObj.type || undefined,
         });
       }
     }

--- a/apps/spa/src/lib/__tests__/files.test.js
+++ b/apps/spa/src/lib/__tests__/files.test.js
@@ -5,6 +5,7 @@ import {
   extractTarGz,
   buildFileTree,
   autoExcludeVCS,
+  inferMimeType,
 } from '../files.js';
 
 // Helper: create a ZIP buffer using fflate's zip function
@@ -87,6 +88,13 @@ describe('extractZip', () => {
     const decoded = new TextDecoder().decode(files[0].data);
     expect(decoded).toBe(content);
   });
+
+  it('infers MIME type from extracted ZIP file paths', async () => {
+    const buf = await makeZip({ 'index.html': '<html></html>', 'assets/logo.png': 'png' });
+    const files = await extractZip(buf);
+    expect(files.find(f => f.path === '/index.html').type).toBe('text/html; charset=UTF-8');
+    expect(files.find(f => f.path === '/assets/logo.png').type).toBe('image/png');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -150,6 +158,34 @@ describe('extractTarGz', () => {
     const files = await extractTarGz(gzBuf);
     const f = files.find(x => x.path.includes('page.html'));
     expect(f.path).toBe('/sub/page.html');
+  });
+
+  it('infers MIME type from extracted TAR entries', async () => {
+    const { createTar } = await import('nanotar');
+    const { gzip } = await import('fflate');
+
+    const tarBuf = createTar([{ name: 'styles/site.css', data: 'body {}' }]);
+    const gzBuf = await new Promise((resolve, reject) => {
+      gzip(new Uint8Array(tarBuf), (err, data) =>
+        err ? reject(err) : resolve(data.buffer)
+      );
+    });
+
+    const files = await extractTarGz(gzBuf);
+    expect(files.find(f => f.path === '/styles/site.css').type).toBe('text/css; charset=UTF-8');
+  });
+});
+
+describe('inferMimeType', () => {
+  it('returns known MIME types from file extensions', () => {
+    expect(inferMimeType('/index.html')).toBe('text/html; charset=UTF-8');
+    expect(inferMimeType('/app.js')).toBe('text/javascript; charset=UTF-8');
+    expect(inferMimeType('/image.webp')).toBe('image/webp');
+  });
+
+  it('returns undefined for unknown extensions', () => {
+    expect(inferMimeType('/README.unknown')).toBeUndefined();
+    expect(inferMimeType('/no-extension')).toBeUndefined();
   });
 });
 

--- a/apps/spa/src/lib/__tests__/upload.test.js
+++ b/apps/spa/src/lib/__tests__/upload.test.js
@@ -386,4 +386,52 @@ describe('uploadBlobs', () => {
 
     globalThis.fetch = origFetch;
   });
+
+  it('sends each file MIME type in upload headers when provided', async () => {
+    const files = [
+      { ...makeFile('index.html'), type: 'text/html; charset=utf-8' },
+      { ...makeFile('app.js'), type: 'application/javascript' },
+    ];
+    const existing = new Map();
+    const signer = fakeSigner();
+    const servers = [S1];
+
+    const seenHeaders = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_url, opts) => {
+      if (opts?.method === 'PUT') seenHeaders.push(opts.headers);
+      return { ok: true, status: 200, text: async () => '' };
+    });
+
+    await uploadBlobs(files, existing, signer, servers);
+
+    expect(seenHeaders).toHaveLength(2);
+    expect(seenHeaders[0]['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(seenHeaders[0]['X-Content-Type']).toBe('text/html; charset=utf-8');
+    expect(seenHeaders[1]['Content-Type']).toBe('application/javascript');
+    expect(seenHeaders[1]['X-Content-Type']).toBe('application/javascript');
+
+    globalThis.fetch = origFetch;
+  });
+
+  it('falls back to application/octet-stream when MIME type is unavailable', async () => {
+    const files = [makeFile('blob.bin')];
+    const existing = new Map();
+    const signer = fakeSigner();
+    const servers = [S1];
+
+    const origFetch = globalThis.fetch;
+    let uploadHeaders = null;
+    globalThis.fetch = vi.fn(async (_url, opts) => {
+      if (opts?.method === 'PUT') uploadHeaders = opts.headers;
+      return { ok: true, status: 200, text: async () => '' };
+    });
+
+    await uploadBlobs(files, existing, signer, servers);
+
+    expect(uploadHeaders['Content-Type']).toBe('application/octet-stream');
+    expect(uploadHeaders['X-Content-Type']).toBeUndefined();
+
+    globalThis.fetch = origFetch;
+  });
 });

--- a/apps/spa/src/lib/files.js
+++ b/apps/spa/src/lib/files.js
@@ -13,6 +13,15 @@
 
 import { unzip, gunzip } from 'fflate';
 import { parseTar } from 'nanotar';
+import { contentType } from '@std/media-types/content-type';
+
+export function inferMimeType(path) {
+  if (!path) return undefined;
+  const dotIndex = path.lastIndexOf('.');
+  if (dotIndex === -1) return undefined;
+  const ext = path.slice(dotIndex).toLowerCase();
+  return contentType(ext);
+}
 
 // ---------------------------------------------------------------------------
 // VCS auto-exclude patterns
@@ -34,7 +43,7 @@ export const VCS_EXCLUDE_SUFFIX = '/.DS_Store';
  * top-level directory (e.g., "dist/index.html" → "/index.html").
  *
  * @param {ArrayBuffer} arrayBuffer
- * @returns {Promise<Array<{path: string, data: Uint8Array, size: number}>>}
+ * @returns {Promise<Array<{path: string, data: Uint8Array, size: number, type?: string}>>}
  */
 export function extractZip(arrayBuffer) {
   return new Promise((resolve, reject) => {
@@ -48,6 +57,7 @@ export function extractZip(arrayBuffer) {
           path: '/' + name,
           data,
           size: data.length,
+          type: inferMimeType(name),
         }));
 
       // Detect and strip common root prefix
@@ -64,8 +74,8 @@ export function extractZip(arrayBuffer) {
  * e.g., ["dist/a.html", "dist/b.js"] → ["/a.html", "/b.js"]
  * e.g., ["index.html", "app.js"]     → ["/index.html", "/app.js"] (no change)
  *
- * @param {Array<{path: string, data: Uint8Array, size: number}>} files
- * @returns {Array<{path: string, data: Uint8Array, size: number}>}
+ * @param {Array<{path: string, data: Uint8Array, size: number, type?: string}>} files
+ * @returns {Array<{path: string, data: Uint8Array, size: number, type?: string}>}
  */
 function stripCommonRootPrefix(files) {
   if (files.length === 0) return files;
@@ -105,7 +115,7 @@ function stripCommonRootPrefix(files) {
  * Filters to file entries only, normalizes paths with leading '/'.
  *
  * @param {ArrayBuffer} arrayBuffer
- * @returns {Promise<Array<{path: string, data: Uint8Array, size: number}>>}
+ * @returns {Promise<Array<{path: string, data: Uint8Array, size: number, type?: string}>>}
  */
 export function extractTarGz(arrayBuffer) {
   return new Promise((resolve, reject) => {
@@ -129,6 +139,7 @@ export function extractTarGz(arrayBuffer) {
             path: '/' + e.name.replace(/^\//, ''), // normalize leading slash
             data,
             size: data.length,
+            type: inferMimeType(e.name),
           };
         });
 
@@ -274,7 +285,7 @@ function sortNodes(nodes) {
  * Open a directory picker dialog. Uses showDirectoryPicker (Chromium)
  * with fallback to a hidden <input webkitdirectory> for Firefox/Safari.
  *
- * @returns {Promise<Array<{path: string, data: Uint8Array, size: number}>>}
+ * @returns {Promise<Array<{path: string, data: Uint8Array, size: number, type?: string}>>}
  */
 export async function pickDirectory() {
   if ('showDirectoryPicker' in window) {
@@ -300,7 +311,7 @@ export async function pickDirectory() {
               const relPath = file.webkitRelativePath;
               const slashIdx = relPath.indexOf('/');
               const path = slashIdx >= 0 ? relPath.slice(slashIdx) : '/' + relPath;
-              return { path, data, size: data.length };
+              return { path, data, size: data.length, type: file.type || inferMimeType(path) };
             })
           );
           resolve(files);
@@ -330,7 +341,7 @@ export async function pickDirectory() {
  * Open an archive file picker dialog (.zip, .tar.gz, .tgz).
  * Extracts the archive based on file extension.
  *
- * @returns {Promise<Array<{path: string, data: Uint8Array, size: number}>>}
+ * @returns {Promise<Array<{path: string, data: Uint8Array, size: number, type?: string}>>}
  */
 export async function pickArchive() {
   return new Promise((resolve, reject) => {
@@ -385,7 +396,7 @@ export async function pickArchive() {
  *
  * @param {FileSystemDirectoryHandle} dirHandle
  * @param {string} basePath - Path prefix accumulated during recursion
- * @returns {Promise<Array<{path: string, data: Uint8Array, size: number}>>}
+ * @returns {Promise<Array<{path: string, data: Uint8Array, size: number, type?: string}>>}
  */
 export async function readDirectoryHandle(dirHandle, basePath) {
   const files = [];
@@ -399,7 +410,7 @@ export async function readDirectoryHandle(dirHandle, basePath) {
     } else {
       const file = await handle.getFile();
       const data = new Uint8Array(await file.arrayBuffer());
-      files.push({ path, data, size: data.length });
+      files.push({ path, data, size: data.length, type: file.type || inferMimeType(path) });
     }
   }
 

--- a/apps/spa/src/lib/upload.js
+++ b/apps/spa/src/lib/upload.js
@@ -288,12 +288,18 @@ export async function uploadBlobs(files, existing, signer, blossomUrls, onProgre
         }
 
         try {
+          const contentType = file.type || 'application/octet-stream';
+          const headers = {
+            Authorization: authHeaders.get(file.sha256),
+            'Content-Type': contentType,
+          };
+          if (file.type) {
+            headers['X-Content-Type'] = file.type;
+          }
+
           const resp = await fetch(`${base}/upload`, {
             method: 'PUT',
-            headers: {
-              Authorization: authHeaders.get(file.sha256),
-              'Content-Type': 'application/octet-stream',
-            },
+            headers,
             body: file.data,
           });
 


### PR DESCRIPTION
## Summary
- preserve browser MIME types during SPA file ingestion and infer archive MIME types with `@std/media-types`
- send per-file `Content-Type` and `X-Content-Type` headers to Blossom uploads, falling back to octet-stream only when unknown
- add SPA tests covering MIME inference and upload header behavior