### PR TITLE
fix: sign one auth event per blob for BUD-02 upload

### DIFF
--- a/apps/spa/src/lib/upload.js
+++ b/apps/spa/src/lib/upload.js
@@ -189,18 +189,16 @@ export async function uploadBlobs(files, existing, signer, blossomUrls, onProgre
   const filesToUploadList = files.filter(f => filesToUpload.has(f.sha256));
   const fullySkippedCount = files.length - filesToUploadList.length;
 
-  // Sign auth for files that need uploading
-  const AUTH_BATCH_SIZE = 50;
+  // Sign auth for files that need uploading — one auth event per file.
+  // The blossom server uses xTags[0][1] as the storage path, so each auth event
+  // must contain exactly the hash of the blob being uploaded as its first (and only) x tag.
+  // Batching multiple hashes into one auth event causes all blobs in the batch to be
+  // stored at the first hash's path, corrupting the upload.
   const authHeaders = new Map();
-  for (let i = 0; i < filesToUploadList.length; i += AUTH_BATCH_SIZE) {
-    const batch = filesToUploadList.slice(i, i + AUTH_BATCH_SIZE);
-    const hashes = batch.map(f => f.sha256);
-    const template = buildAuthEvent(hashes, 'upload');
+  for (const file of filesToUploadList) {
+    const template = buildAuthEvent(file.sha256, 'upload');
     const signed = await signer.signEvent(template);
-    const header = 'Nostr ' + btoa(JSON.stringify(signed));
-    for (const hash of hashes) {
-      authHeaders.set(hash, header);
-    }
+    authHeaders.set(file.sha256, 'Nostr ' + btoa(JSON.stringify(signed)));
   }
 
   // Pre-populate per-server progress


### PR DESCRIPTION
## Summary

- **Critical bug:** Upload auth batched 50 file hashes into a single signed event with multiple x tags. The blossom server uses `xTags[0][1]` as the storage path, so every blob in the batch was written to the first hash's path — corrupting all but one blob per batch.
- Signs one auth event per file, matching the fix already applied to blob deletion in 6d483e2.
- Every deploy with more than 1 file was affected.

## Root Cause

`blob-upload.ts:52` picks `expectedHash = xTags[0][1]` as the storage path regardless of which blob is being uploaded. When a batch auth event contains hashes `[A, B, C, ...]`, uploading blob B stores its content at path A. Hash verification passes because B's hash exists in the x tags list — just not at index 0. On subsequent GET, the blossom reads the file, finds a hash mismatch, and deletes it.

## Test plan

- [ ] Deploy a multi-file site (e.g., SvelteKit build with 21 files)
- [ ] Verify all blobs persist in blossom storage after upload
- [ ] Verify the deployed site loads correctly through the gateway
- [ ] Verify "Already exist" count is correct on re-deploy (all blobs should exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)