### PR TITLE
chore: exclude non-Deno packages from fmt/lint/test

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,15 +17,51 @@
   "fmt": {
     "lineWidth": 100,
     "singleQuote": false,
-    "exclude": [".planning/", ".git/", "apps/spa/", ".github/", "docs/", "test-results/", ".nsite/"]
+    "exclude": [
+      ".planning/",
+      ".git/",
+      ".worktrees/",
+      "apps/spa/",
+      ".github/",
+      "docs/",
+      "test-results/",
+      ".nsite/",
+      "node_modules/",
+      "packages/deployer/",
+      "packages/stealthis/"
+    ]
   },
   "lint": {
     "rules": {
       "tags": ["recommended"]
     },
-    "exclude": [".planning/", ".git/", "apps/spa/", ".github/", "docs/", "test-results/", ".nsite/"]
+    "exclude": [
+      ".planning/",
+      ".git/",
+      ".worktrees/",
+      "apps/spa/",
+      ".github/",
+      "docs/",
+      "test-results/",
+      ".nsite/",
+      "node_modules/",
+      "packages/deployer/",
+      "packages/stealthis/"
+    ]
   },
   "test": {
-    "exclude": [".planning/", ".git/", "apps/spa/", ".github/", "docs/", "test-results/", ".nsite/"]
+    "exclude": [
+      ".planning/",
+      ".git/",
+      ".worktrees/",
+      "apps/spa/",
+      ".github/",
+      "docs/",
+      "test-results/",
+      ".nsite/",
+      "node_modules/",
+      "packages/deployer/",
+      "packages/stealthis/"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `.worktrees/`, `node_modules/`, `packages/deployer/`, `packages/stealthis/` to deno.json fmt/lint/test exclude lists
- These are npm packages or git worktree directories that should not be checked by Deno tooling

## Test plan
- [x] `deno fmt --check`, `deno lint`, `deno test` still pass on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)