### PR TITLE
feat: stealthis theming + copyDittoTheme

### DIFF
--- a/packages/stealthis/README.md
+++ b/packages/stealthis/README.md
@@ -31,6 +31,11 @@ If you want to control where the button appears, add the element yourself (the a
 | `no-trail` | _(absent)_ | Boolean attribute. When present, disables the paper trail entirely -- no `muse` tags are written and the trail UI is not rendered. |
 | `obfuscate-npubs` | _(absent)_ | Boolean attribute. Shows truncated npubs with no links in the paper trail. Disables profile fetching. |
 | `do-not-fetch-muse-data` | _(absent)_ | Boolean attribute. Skips profile enrichment but still shows full npubs linked to njump. |
+| `accent` | `#9b59b6` | Accent color for buttons, links, active states, and spinner. When set without `background`, modal surfaces are also derived from this color. |
+| `background` | `#1a1a2e` | Modal background color. Input fills and borders are derived as darker shades. |
+| `text` | `#e0e0e0` | Text color. Muted and dim variants are derived at 50% and 65% transparency. |
+| `radius` | `8px` | Border radius for buttons, modal, and inputs. Inner elements scale proportionally. |
+| `copy-ditto-theme` | _(absent)_ | An `naddr` pointing to a Ditto theme event (kind 36767 or 16767). When set, the deploy flow includes a step to copy the theme to the user's profile. See [Ditto NIP](https://github.com/soapbox-pub/ditto/blob/main/NIP.md). |
 
 The button's `trigger` part is exposed via `::part(trigger)` for CSS customization.
 

--- a/packages/stealthis/src/nostr.ts
+++ b/packages/stealthis/src/nostr.ts
@@ -431,10 +431,26 @@ export function buildSiteUrl(
 
 // --- Ditto theme resolution ---
 
+export interface DittoThemeFont {
+  family: string;
+  url: string;
+  role: "body" | "title";
+}
+
+export interface DittoThemeBg {
+  url: string;
+  mode: "cover" | "tile";
+  mime: string;
+  dim?: string;
+  blurhash?: string;
+}
+
 export interface DittoTheme {
-  primary: string;
-  background: string;
-  text: string;
+  title?: string;
+  colors: { primary: string; background: string; text: string };
+  fonts: DittoThemeFont[];
+  bg?: DittoThemeBg;
+  event: RelayEvent;
 }
 
 export async function fetchDittoTheme(naddr: string): Promise<DittoTheme | null> {
@@ -461,20 +477,99 @@ export async function fetchDittoTheme(naddr: string): Promise<DittoTheme | null>
 
     const event = events.sort((a, b) => b.created_at - a.created_at)[0];
 
-    // Ditto themes store colors in c tags: ["c", "#rrggbb", "primary"|"text"|"background"]
+    // Colors: c tags — ["c", "#rrggbb", "primary"|"text"|"background"]
     let primary: string | undefined;
     let background: string | undefined;
     let text: string | undefined;
+    // Fonts: f tags — ["f", "family", "url", "role"]
+    const fonts: DittoThemeFont[] = [];
+    // Background: bg tag — ["bg", "url <url>", "mode <mode>", "m <mime>", ...]
+    let bg: DittoThemeBg | undefined;
+    // Title: title tag
+    let title: string | undefined;
+
     for (const tag of event.tags) {
       if (tag[0] === "c" && tag[1] && tag[2]) {
         if (tag[2] === "primary") primary = tag[1];
         else if (tag[2] === "background") background = tag[1];
         else if (tag[2] === "text") text = tag[1];
+      } else if (tag[0] === "f" && tag[1] && tag[2]) {
+        const role = (tag[3] || "body") as "body" | "title";
+        if (role === "body" || role === "title") {
+          fonts.push({ family: tag[1], url: tag[2], role });
+        }
+      } else if (tag[0] === "bg") {
+        // Imeta-style variadic: each element after index 0 is "key value"
+        const kv: Record<string, string> = {};
+        for (let i = 1; i < tag.length; i++) {
+          const space = tag[i].indexOf(" ");
+          if (space > 0) kv[tag[i].slice(0, space)] = tag[i].slice(space + 1);
+        }
+        if (kv.url && kv.mode && kv.m) {
+          bg = {
+            url: kv.url,
+            mode: kv.mode as "cover" | "tile",
+            mime: kv.m,
+            dim: kv.dim,
+            blurhash: kv.blurhash,
+          };
+        }
+      } else if (tag[0] === "title" && tag[1]) {
+        title = tag[1];
       }
     }
+
     if (!primary || !background || !text) return null;
-    return { primary, background, text };
+    return {
+      title,
+      colors: { primary, background, text },
+      fonts,
+      bg,
+      event,
+    };
   } catch {
     return null;
   }
+}
+
+export function createActiveThemeEvent(theme: DittoTheme): EventTemplate {
+  const tags: string[][] = [];
+  // Colors (required)
+  tags.push(["c", theme.colors.primary, "primary"]);
+  tags.push(["c", theme.colors.text, "text"]);
+  tags.push(["c", theme.colors.background, "background"]);
+  // Fonts (optional, preserve order: body before title)
+  const bodyFont = theme.fonts.find((f) => f.role === "body");
+  const titleFont = theme.fonts.find((f) => f.role === "title");
+  if (bodyFont) tags.push(["f", bodyFont.family, bodyFont.url, "body"]);
+  if (titleFont) tags.push(["f", titleFont.family, titleFont.url, "title"]);
+  // Background (optional)
+  if (theme.bg) {
+    const parts = [`url ${theme.bg.url}`, `mode ${theme.bg.mode}`, `m ${theme.bg.mime}`];
+    if (theme.bg.dim) parts.push(`dim ${theme.bg.dim}`);
+    if (theme.bg.blurhash) parts.push(`blurhash ${theme.bg.blurhash}`);
+    tags.push(["bg", ...parts]);
+  }
+  // Title (optional)
+  if (theme.title) tags.push(["title", theme.title]);
+  // Alt (required per NIP-31)
+  tags.push(["alt", "Active profile theme"]);
+  return {
+    kind: 16767,
+    created_at: Math.floor(Date.now() / 1000),
+    tags,
+    content: "",
+  };
+}
+
+export async function checkExistingTheme(
+  relays: string[],
+  pubkey: string,
+): Promise<boolean> {
+  const events = await queryRelays(relays, {
+    kinds: [16767],
+    authors: [pubkey],
+    limit: 1,
+  });
+  return events.length > 0;
 }

--- a/packages/stealthis/src/nostr.ts
+++ b/packages/stealthis/src/nostr.ts
@@ -459,6 +459,7 @@ export async function fetchDittoTheme(naddr: string): Promise<DittoTheme | null>
     const result = decode(naddr);
     if (result.type !== "naddr") return null;
     const { identifier, pubkey, kind, relays: naddrRelays } = result.data;
+    if (kind !== 36767 && kind !== 16767) return null;
 
     // Build deduped relay list: naddr hints first, then bootstrap fallback
     const seen = new Set<string>();

--- a/packages/stealthis/src/nostr.ts
+++ b/packages/stealthis/src/nostr.ts
@@ -432,10 +432,9 @@ export function buildSiteUrl(
 // --- Ditto theme resolution ---
 
 export interface DittoTheme {
-  accent?: string;
-  background?: string;
-  text?: string;
-  radius?: string;
+  primary: string;
+  background: string;
+  text: string;
 }
 
 export async function fetchDittoTheme(naddr: string): Promise<DittoTheme | null> {
@@ -461,13 +460,20 @@ export async function fetchDittoTheme(naddr: string): Promise<DittoTheme | null>
     if (events.length === 0) return null;
 
     const event = events.sort((a, b) => b.created_at - a.created_at)[0];
-    const meta = JSON.parse(event.content);
-    const theme: DittoTheme = {};
-    if (typeof meta.accent === "string" && meta.accent) theme.accent = meta.accent;
-    if (typeof meta.background === "string" && meta.background) theme.background = meta.background;
-    if (typeof meta.text === "string" && meta.text) theme.text = meta.text;
-    if (typeof meta.radius === "string" && meta.radius) theme.radius = meta.radius;
-    return theme;
+
+    // Ditto themes store colors in c tags: ["c", "#rrggbb", "primary"|"text"|"background"]
+    let primary: string | undefined;
+    let background: string | undefined;
+    let text: string | undefined;
+    for (const tag of event.tags) {
+      if (tag[0] === "c" && tag[1] && tag[2]) {
+        if (tag[2] === "primary") primary = tag[1];
+        else if (tag[2] === "background") background = tag[1];
+        else if (tag[2] === "text") text = tag[1];
+      }
+    }
+    if (!primary || !background || !text) return null;
+    return { primary, background, text };
   } catch {
     return null;
   }

--- a/packages/stealthis/src/nostr.ts
+++ b/packages/stealthis/src/nostr.ts
@@ -428,3 +428,47 @@ export function buildSiteUrl(
   }
   return `https://${npubEncode(pubkey)}.${baseDomain}`;
 }
+
+// --- Ditto theme resolution ---
+
+export interface DittoTheme {
+  accent?: string;
+  background?: string;
+  text?: string;
+  radius?: string;
+}
+
+export async function fetchDittoTheme(naddr: string): Promise<DittoTheme | null> {
+  if (!naddr) return null;
+  try {
+    const result = decode(naddr);
+    if (result.type !== "naddr") return null;
+    const { identifier, pubkey, kind, relays: naddrRelays } = result.data;
+
+    // Build deduped relay list: naddr hints first, then bootstrap fallback
+    const seen = new Set<string>();
+    const urls: string[] = [];
+    for (const r of [...(naddrRelays ?? []), ...BOOTSTRAP_RELAYS]) {
+      if (!seen.has(r)) { seen.add(r); urls.push(r); }
+    }
+
+    const events = await queryRelays(urls, {
+      kinds: [kind],
+      authors: [pubkey],
+      "#d": [identifier],
+      limit: 1,
+    });
+    if (events.length === 0) return null;
+
+    const event = events.sort((a, b) => b.created_at - a.created_at)[0];
+    const meta = JSON.parse(event.content);
+    const theme: DittoTheme = {};
+    if (typeof meta.accent === "string" && meta.accent) theme.accent = meta.accent;
+    if (typeof meta.background === "string" && meta.background) theme.background = meta.background;
+    if (typeof meta.text === "string" && meta.text) theme.text = meta.text;
+    if (typeof meta.radius === "string" && meta.radius) theme.radius = meta.radius;
+    return theme;
+  } catch {
+    return null;
+  }
+}

--- a/packages/stealthis/src/styles.css
+++ b/packages/stealthis/src/styles.css
@@ -436,6 +436,59 @@
 	font-style: italic;
 }
 
+/* Ditto theme preview */
+.nd-theme-name {
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--steal-this-text, #e0e0e0);
+	margin-bottom: 12px;
+}
+.nd-theme-section {
+	margin-bottom: 12px;
+}
+.nd-theme-label {
+	font-size: 11px;
+	color: var(--steal-this-muted, #888);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	margin-bottom: 6px;
+}
+.nd-theme-colors {
+	display: flex;
+	gap: 12px;
+}
+.nd-theme-swatch {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+.nd-swatch {
+	display: inline-block;
+	width: 20px;
+	height: 20px;
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.5);
+	border: 1px solid var(--steal-this-border, #0f3460);
+}
+.nd-swatch-label {
+	font-size: 11px;
+	color: var(--steal-this-muted, #888);
+	font-family: monospace;
+}
+.nd-theme-font {
+	font-size: 13px;
+	color: var(--steal-this-text, #e0e0e0);
+	padding: 2px 0;
+}
+.nd-theme-role {
+	font-size: 11px;
+	color: var(--steal-this-muted, #888);
+	margin-left: 4px;
+}
+.nd-theme-bg-info {
+	font-size: 13px;
+	color: var(--steal-this-muted, #888);
+}
+
 @keyframes nd-spin {
 	to { transform: rotate(360deg); }
 }

--- a/packages/stealthis/src/styles.css
+++ b/packages/stealthis/src/styles.css
@@ -5,16 +5,16 @@
 
 .nd-trigger {
 	padding: 10px 18px;
-	background: #9b59b6;
+	background: var(--steal-this-accent, #9b59b6);
 	color: #fff;
 	border: none;
-	border-radius: 8px;
+	border-radius: var(--steal-this-radius, 8px);
 	font-size: 14px;
 	font-weight: 600;
 	cursor: pointer;
 	transition: background 0.2s;
 }
-.nd-trigger:hover { background: #8e44ad; }
+.nd-trigger:hover { background: var(--steal-this-accent-hover, color-mix(in srgb, var(--steal-this-accent, #9b59b6), black 15%)); }
 .nd-trigger:disabled { opacity: 0.6; cursor: default; }
 :host(.nd-fixed) .nd-trigger {
 	position: fixed;
@@ -36,13 +36,13 @@
 }
 
 .nd-modal {
-	background: #1a1a2e;
-	border: 1px solid #0f3460;
-	border-radius: 12px;
+	background: var(--steal-this-bg, #1a1a2e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: var(--steal-this-radius, 8px);
 	padding: 24px;
 	width: 90%;
 	max-width: 420px;
-	color: #e0e0e0;
+	color: var(--steal-this-text, #e0e0e0);
 	max-height: 90vh;
 	overflow-y: auto;
 }
@@ -61,13 +61,13 @@
 .nd-close {
 	background: none;
 	border: none;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 	font-size: 22px;
 	cursor: pointer;
 	padding: 0 0 0 8px;
 	line-height: 1;
 }
-.nd-close:hover { color: #e0e0e0; }
+.nd-close:hover { color: var(--steal-this-text, #e0e0e0); }
 
 /* Auth section */
 .nd-auth-option {
@@ -83,7 +83,7 @@
 	gap: 12px;
 	margin: 16px 0;
 	font-size: 12px;
-	color: #555;
+	color: var(--steal-this-dim, #555);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 }
@@ -91,22 +91,22 @@
 	content: '';
 	flex: 1;
 	height: 1px;
-	background: #0f3460;
+	background: var(--steal-this-border, #0f3460);
 }
 
 .nd-btn-ext {
 	width: 100%;
 	padding: 12px;
-	background: #9b59b6;
+	background: var(--steal-this-accent, #9b59b6);
 	color: #fff;
 	border: none;
-	border-radius: 8px;
+	border-radius: var(--steal-this-radius, 8px);
 	font-size: 14px;
 	font-weight: 600;
 	cursor: pointer;
 	transition: background 0.2s;
 }
-.nd-btn-ext:hover { background: #8e44ad; }
+.nd-btn-ext:hover { background: var(--steal-this-accent-hover, color-mix(in srgb, var(--steal-this-accent, #9b59b6), black 15%)); }
 
 .nd-bunker-row {
 	display: flex;
@@ -115,10 +115,10 @@
 .nd-bunker-row input {
 	flex: 1;
 	padding: 8px 12px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 6px;
-	color: #e0e0e0;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
+	color: var(--steal-this-text, #e0e0e0);
 	font-size: 13px;
 	font-family: inherit;
 	box-sizing: border-box;
@@ -126,20 +126,20 @@
 }
 .nd-bunker-row input:focus {
 	outline: none;
-	border-color: #9b59b6;
+	border-color: var(--steal-this-accent, #9b59b6);
 }
 .nd-bunker-row button {
 	padding: 8px 14px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 6px;
-	color: #e0e0e0;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
+	color: var(--steal-this-text, #e0e0e0);
 	font-size: 13px;
 	font-weight: 600;
 	cursor: pointer;
 	white-space: nowrap;
 }
-.nd-bunker-row button:hover { background: #0f3460; }
+.nd-bunker-row button:hover { background: var(--steal-this-border, #0f3460); }
 
 .nd-qr-wrap {
 	display: flex;
@@ -149,11 +149,11 @@
 }
 .nd-qr-label {
 	font-size: 12px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 }
 .nd-qr-code {
 	background: #fff;
-	border-radius: 8px;
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
 	padding: 12px;
 	display: inline-flex;
 }
@@ -170,11 +170,11 @@
 }
 .nd-relay-row label {
 	padding: 6px 10px;
-	background: #0f3460;
-	border: 1px solid #0f3460;
+	background: var(--steal-this-border, #0f3460);
+	border: 1px solid var(--steal-this-border, #0f3460);
 	border-right: none;
-	border-radius: 4px 0 0 4px;
-	color: #888;
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.5) 0 0 calc(var(--steal-this-radius, 8px) * 0.5);
+	color: var(--steal-this-muted, #888);
 	font-size: 11px;
 	white-space: nowrap;
 	display: flex;
@@ -183,10 +183,10 @@
 .nd-relay-row input {
 	flex: 1;
 	padding: 6px 8px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 0 4px 4px 0;
-	color: #e0e0e0;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: 0 calc(var(--steal-this-radius, 8px) * 0.5) calc(var(--steal-this-radius, 8px) * 0.5) 0;
+	color: var(--steal-this-text, #e0e0e0);
 	font-size: 11px;
 	font-family: monospace;
 	min-width: 0;
@@ -194,7 +194,7 @@
 }
 .nd-relay-row input:focus {
 	outline: none;
-	border-color: #9b59b6;
+	border-color: var(--steal-this-accent, #9b59b6);
 }
 .nd-qr-uri {
 	display: flex;
@@ -205,10 +205,10 @@
 .nd-qr-uri input {
 	flex: 1;
 	padding: 6px 8px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 4px;
-	color: #888;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.5);
+	color: var(--steal-this-muted, #888);
 	font-size: 11px;
 	font-family: monospace;
 	min-width: 0;
@@ -216,22 +216,22 @@
 }
 .nd-qr-uri button {
 	padding: 6px 10px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 4px;
-	color: #e0e0e0;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.5);
+	color: var(--steal-this-text, #e0e0e0);
 	font-size: 11px;
 	cursor: pointer;
 	white-space: nowrap;
 }
-.nd-qr-uri button:hover { background: #0f3460; }
+.nd-qr-uri button:hover { background: var(--steal-this-border, #0f3460); }
 
 /* Toggle */
 .nd-toggle {
 	display: flex;
 	margin-bottom: 16px;
-	background: #16213e;
-	border-radius: 6px;
+	background: var(--steal-this-input-bg, #16213e);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
 	padding: 3px;
 }
 .nd-toggle-btn {
@@ -239,15 +239,15 @@
 	padding: 8px;
 	background: transparent;
 	border: none;
-	border-radius: 4px;
-	color: #888;
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.5);
+	color: var(--steal-this-muted, #888);
 	font-size: 13px;
 	font-weight: 600;
 	cursor: pointer;
 	transition: all 0.2s;
 }
 .nd-toggle-btn.active {
-	background: #9b59b6;
+	background: var(--steal-this-accent, #9b59b6);
 	color: #fff;
 }
 
@@ -255,7 +255,7 @@
 .nd-warn {
 	background: rgba(231, 76, 60, 0.1);
 	border: 1px solid rgba(231, 76, 60, 0.3);
-	border-radius: 6px;
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
 	padding: 12px;
 	font-size: 13px;
 	color: #e74c3c;
@@ -269,12 +269,12 @@
 
 .nd-root-hint {
 	font-size: 13px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 	margin-bottom: 12px;
 	word-break: break-all;
 }
 .nd-root-hint strong {
-	color: #e0e0e0;
+	color: var(--steal-this-text, #e0e0e0);
 }
 
 /* Form fields */
@@ -284,7 +284,7 @@
 .nd-field label {
 	display: block;
 	font-size: 11px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 	margin-bottom: 4px;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
@@ -292,17 +292,17 @@
 .nd-field input, .nd-field textarea {
 	width: 100%;
 	padding: 8px 12px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 6px;
-	color: #e0e0e0;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
+	color: var(--steal-this-text, #e0e0e0);
 	font-size: 14px;
 	font-family: inherit;
 	box-sizing: border-box;
 }
 .nd-field input:focus, .nd-field textarea:focus {
 	outline: none;
-	border-color: #9b59b6;
+	border-color: var(--steal-this-accent, #9b59b6);
 }
 .nd-field textarea {
 	resize: vertical;
@@ -310,7 +310,7 @@
 }
 .nd-hint {
 	font-size: 11px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 	margin-top: 3px;
 }
 .nd-field-error {
@@ -329,30 +329,30 @@
 	flex: 1;
 	padding: 10px;
 	border: none;
-	border-radius: 6px;
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
 	font-size: 14px;
 	font-weight: 600;
 	cursor: pointer;
 	transition: background 0.2s;
 }
 .nd-btn-primary {
-	background: #9b59b6;
+	background: var(--steal-this-accent, #9b59b6);
 	color: #fff;
 }
-.nd-btn-primary:hover { background: #8e44ad; }
+.nd-btn-primary:hover { background: var(--steal-this-accent-hover, color-mix(in srgb, var(--steal-this-accent, #9b59b6), black 15%)); }
 .nd-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 .nd-btn-secondary {
-	background: #16213e;
-	color: #e0e0e0;
-	border: 1px solid #0f3460;
+	background: var(--steal-this-input-bg, #16213e);
+	color: var(--steal-this-text, #e0e0e0);
+	border: 1px solid var(--steal-this-border, #0f3460);
 }
-.nd-btn-secondary:hover { background: #0f3460; }
+.nd-btn-secondary:hover { background: var(--steal-this-border, #0f3460); }
 
 /* Status */
 .nd-status {
 	margin-top: 12px;
 	font-size: 13px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 }
 .nd-status-ok { color: #2ecc71; }
 .nd-status-err { color: #e74c3c; }
@@ -361,22 +361,22 @@
 	display: block;
 	margin-top: 12px;
 	padding: 10px;
-	background: #16213e;
-	border: 1px solid #0f3460;
-	border-radius: 6px;
-	color: #9b59b6;
+	background: var(--steal-this-input-bg, #16213e);
+	border: 1px solid var(--steal-this-border, #0f3460);
+	border-radius: calc(var(--steal-this-radius, 8px) * 0.75);
+	color: var(--steal-this-accent, #9b59b6);
 	text-decoration: none;
 	text-align: center;
 	font-size: 13px;
 	word-break: break-all;
 }
-.nd-link:hover { background: #0f3460; }
+.nd-link:hover { background: var(--steal-this-border, #0f3460); }
 
 .nd-msg {
 	text-align: center;
 	padding: 20px 0;
 	font-size: 14px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 }
 
 /* Paper trail */
@@ -387,18 +387,18 @@
 .nd-trail-toggle {
 	background: none;
 	border: none;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 	font-size: 12px;
 	cursor: pointer;
 	padding: 4px 8px;
 	transition: color 0.2s;
 }
-.nd-trail-toggle:hover { color: #e0e0e0; }
+.nd-trail-toggle:hover { color: var(--steal-this-text, #e0e0e0); }
 .nd-trail-list {
 	margin-top: 6px;
 	text-align: left;
 	font-size: 12px;
-	color: #888;
+	color: var(--steal-this-muted, #888);
 	max-height: 200px;
 	overflow-y: auto;
 }
@@ -410,15 +410,15 @@
 	gap: 6px;
 }
 .nd-trail-idx {
-	color: #555;
+	color: var(--steal-this-dim, #555);
 	min-width: 24px;
 	text-align: right;
 }
 .nd-trail-pk {
-	color: #9b59b6;
+	color: var(--steal-this-accent, #9b59b6);
 }
 .nd-trail-link {
-	color: #9b59b6;
+	color: var(--steal-this-accent, #9b59b6);
 	text-decoration: none;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -427,12 +427,12 @@
 	transition: color 0.2s;
 }
 .nd-trail-link:hover {
-	color: #c39bd3;
+	color: color-mix(in srgb, var(--steal-this-accent, #9b59b6), white 40%);
 	text-decoration: underline;
 }
 .nd-trail-gap {
 	padding: 3px 0;
-	color: #555;
+	color: var(--steal-this-dim, #555);
 	font-style: italic;
 }
 
@@ -443,8 +443,8 @@
 	display: inline-block;
 	width: 18px;
 	height: 18px;
-	border: 2px solid #555;
-	border-top-color: #9b59b6;
+	border: 2px solid var(--steal-this-dim, #555);
+	border-top-color: var(--steal-this-accent, #9b59b6);
 	border-radius: 50%;
 	animation: nd-spin 0.8s linear infinite;
 	vertical-align: middle;

--- a/packages/stealthis/src/widget.ts
+++ b/packages/stealthis/src/widget.ts
@@ -28,6 +28,10 @@ export class NsiteDeployButton extends HTMLElement {
     "no-trail",
     "obfuscate-npubs",
     "do-not-fetch-muse-data",
+    "accent",
+    "background",
+    "text",
+    "radius",
   ];
 
   private shadow: ShadowRoot;
@@ -94,6 +98,36 @@ export class NsiteDeployButton extends HTMLElement {
     if (this.state === "idle") this.render();
   }
 
+  private get themeVars(): string {
+    const accent = this.getAttribute("accent");
+    const background = this.getAttribute("background");
+    const text = this.getAttribute("text");
+    const radius = this.getAttribute("radius");
+
+    const vars: string[] = [];
+    if (accent) {
+      vars.push(`--steal-this-accent: ${accent};`);
+      vars.push(`--steal-this-accent-hover: color-mix(in srgb, ${accent}, black 15%);`);
+    }
+    if (background) {
+      // Derive input-bg as slightly darker, border as darker still
+      vars.push(`--steal-this-bg: ${background};`);
+      vars.push(`--steal-this-input-bg: color-mix(in srgb, ${background}, black 20%);`);
+      vars.push(`--steal-this-border: color-mix(in srgb, ${background}, black 45%);`);
+    }
+    if (text) {
+      vars.push(`--steal-this-text: ${text};`);
+      vars.push(`--steal-this-muted: color-mix(in srgb, ${text}, transparent 50%);`);
+      vars.push(`--steal-this-dim: color-mix(in srgb, ${text}, transparent 65%);`);
+    }
+    if (radius) {
+      vars.push(`--steal-this-radius: ${radius};`);
+    }
+
+    if (vars.length === 0) return "";
+    return `:host { ${vars.join(" ")} }`;
+  }
+
   private get buttonText(): string {
     return this.getAttribute("button-text") || "Borrow this nsite";
   }
@@ -116,7 +150,8 @@ export class NsiteDeployButton extends HTMLElement {
 
   private render() {
     this.preserveFormValues();
-    let html = `<style>${STYLES}</style>`;
+    const themeBlock = this.themeVars;
+    let html = `<style>${themeBlock ? themeBlock + "\n" : ""}${STYLES}</style>`;
 
     switch (this.state) {
       case "idle":

--- a/packages/stealthis/src/widget.ts
+++ b/packages/stealthis/src/widget.ts
@@ -136,6 +136,22 @@ export class NsiteDeployButton extends HTMLElement {
         "--steal-this-accent-hover",
         `color-mix(in srgb, ${accent}, black 15%)`,
       );
+      // If no explicit background set, derive border/input-bg from accent
+      // so the modal feels cohesive with just an accent color
+      if (!background) {
+        this.style.setProperty(
+          "--steal-this-border",
+          `color-mix(in srgb, ${accent}, black 70%)`,
+        );
+        this.style.setProperty(
+          "--steal-this-input-bg",
+          `color-mix(in srgb, ${accent}, black 80%)`,
+        );
+        this.style.setProperty(
+          "--steal-this-bg",
+          `color-mix(in srgb, ${accent}, black 85%)`,
+        );
+      }
     }
     if (background) {
       this.style.setProperty("--steal-this-bg", background);

--- a/packages/stealthis/src/widget.ts
+++ b/packages/stealthis/src/widget.ts
@@ -15,6 +15,7 @@ type State =
   | "auth"
   | "connecting"
   | "loading"
+  | "ditto-theme"
   | "form"
   | "confirm"
   | "deploying"
@@ -61,6 +62,7 @@ export class NsiteDeployButton extends HTMLElement {
   private musesExpanded = false;
   private dittoThemePromise: Promise<nostr.DittoTheme | null> | null = null;
   private _dittoTheme: nostr.DittoTheme | null = null;
+  private hasExistingTheme: boolean | null = null;
 
   get dittoTheme(): nostr.DittoTheme | null {
     return this._dittoTheme;
@@ -200,6 +202,13 @@ export class NsiteDeployButton extends HTMLElement {
         html += this.modal(`
           <div class="nd-msg"><span class="nd-spinner"></span>Fetching site manifest...</div>
         `);
+        break;
+
+      case "ditto-theme":
+        html += `<button class="nd-trigger" disabled>${
+          this.esc(this.buttonText)
+        }</button>`;
+        html += this.modal(this.dittoThemeContent());
         break;
 
       case "form":
@@ -460,6 +469,63 @@ export class NsiteDeployButton extends HTMLElement {
       </div>`;
   }
 
+  private dittoThemeContent(): string {
+    const theme = this._dittoTheme!;
+    const title = theme.title ? this.esc(theme.title) : "Ditto Theme";
+
+    let html = `
+      <div class="nd-header">
+        <h2 class="nd-title">Copy Theme</h2>
+        <button class="nd-close" data-action="close">&times;</button>
+      </div>
+      <div class="nd-theme-name">${title}</div>
+      <div class="nd-theme-section">
+        <div class="nd-theme-label">Colors</div>
+        <div class="nd-theme-colors">
+          <div class="nd-theme-swatch">
+            <span class="nd-swatch" style="background:${this.esc(theme.colors.primary)}"></span>
+            <span class="nd-swatch-label">Primary ${this.esc(theme.colors.primary)}</span>
+          </div>
+          <div class="nd-theme-swatch">
+            <span class="nd-swatch" style="background:${this.esc(theme.colors.background)}"></span>
+            <span class="nd-swatch-label">Background ${this.esc(theme.colors.background)}</span>
+          </div>
+          <div class="nd-theme-swatch">
+            <span class="nd-swatch" style="background:${this.esc(theme.colors.text)}"></span>
+            <span class="nd-swatch-label">Text ${this.esc(theme.colors.text)}</span>
+          </div>
+        </div>
+      </div>`;
+
+    if (theme.fonts.length > 0) {
+      html += `<div class="nd-theme-section">
+        <div class="nd-theme-label">Fonts</div>`;
+      for (const f of theme.fonts) {
+        html += `<div class="nd-theme-font">${this.esc(f.family)} <span class="nd-theme-role">${this.esc(f.role)}</span></div>`;
+      }
+      html += `</div>`;
+    }
+
+    if (theme.bg) {
+      html += `<div class="nd-theme-section">
+        <div class="nd-theme-label">Background</div>
+        <div class="nd-theme-bg-info">${this.esc(theme.bg.mode)} &middot; ${this.esc(theme.bg.mime)}</div>
+      </div>`;
+    }
+
+    if (this.hasExistingTheme === true) {
+      html += `<div class="nd-warn">This will replace your current Ditto theme.</div>`;
+    }
+
+    html += `
+      <div class="nd-actions">
+        <button class="nd-btn nd-btn-secondary" data-action="skip-theme">Skip</button>
+        <button class="nd-btn nd-btn-primary" data-action="copy-theme">Copy theme</button>
+      </div>`;
+
+    return html;
+  }
+
   // --- Bindings ---
 
   private bind() {
@@ -475,6 +541,12 @@ export class NsiteDeployButton extends HTMLElement {
     this.shadow
       .querySelector('[data-action="confirm-deploy"]')
       ?.addEventListener("click", () => this.executeDeploy());
+    this.shadow
+      .querySelector('[data-action="copy-theme"]')
+      ?.addEventListener("click", () => this.copyDittoTheme());
+    this.shadow
+      .querySelector('[data-action="skip-theme"]')
+      ?.addEventListener("click", () => this.setState("form"));
     this.shadow
       .querySelector('[data-action="back"]')
       ?.addEventListener("click", () => this.setState("form"));
@@ -677,23 +749,70 @@ export class NsiteDeployButton extends HTMLElement {
       this.slug = this.ctx!.identifier ?? "";
       this.deployAsRoot = true;
       this.hasRootSite = null;
+      this.hasExistingTheme = null;
 
-      // Show form immediately — don't block on relay discovery
-      this.setState("form");
+      // If a Ditto theme was resolved, show the copy step before the form
+      if (this._dittoTheme) {
+        this.setState("ditto-theme");
+      } else {
+        this.setState("form");
+      }
 
-      // Background: fetch relays, then check if root site exists
+      // Background: fetch relays, then check if root site exists + existing theme
       this.relaysPromise = nostr.getWriteRelays(this.userPubkey);
       this.relaysPromise.then(async (relays) => {
         this.userRelays = relays;
-        const hasRoot = await nostr.checkExistingSite(relays, this.userPubkey);
+        const [hasRoot, hasTheme] = await Promise.all([
+          nostr.checkExistingSite(relays, this.userPubkey),
+          nostr.checkExistingTheme(relays, this.userPubkey),
+        ]);
         this.hasRootSite = hasRoot;
+        this.hasExistingTheme = hasTheme;
         if (hasRoot && this.state === "form" && this.deployAsRoot) {
           this.deployAsRoot = false;
         }
-        if (this.state === "form") this.render();
+        if (this.state === "form" || this.state === "ditto-theme") this.render();
       });
     } catch (err) {
       this.showError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // --- Ditto theme copy ---
+
+  private async copyDittoTheme() {
+    if (!this._dittoTheme || !this.signer) return;
+
+    this.statusMsg = "Creating theme event...";
+    this.setState("deploying");
+
+    try {
+      // Ensure relays are ready
+      if (this.relaysPromise) {
+        this.userRelays = await this.relaysPromise;
+      }
+      if (this.userRelays.length === 0) {
+        this.userRelays = await nostr.getWriteRelays(this.userPubkey);
+      }
+
+      const unsigned = nostr.createActiveThemeEvent(this._dittoTheme);
+
+      this.statusMsg = "Waiting for signature...";
+      this.render();
+      const signed = await this.signer.signEvent(unsigned);
+
+      this.statusMsg = `Publishing theme to ${this.userRelays.length} relay${
+        this.userRelays.length === 1 ? "" : "s"
+      }...`;
+      this.render();
+      await nostr.publishToRelays(this.userRelays, signed);
+
+      // Continue to deploy form regardless of publish result
+      this.setState("form");
+    } catch (err) {
+      // Theme copy failure is non-fatal — continue to deploy form
+      console.warn("Failed to copy Ditto theme:", err);
+      this.setState("form");
     }
   }
 

--- a/packages/stealthis/src/widget.ts
+++ b/packages/stealthis/src/widget.ts
@@ -71,6 +71,7 @@ export class NsiteDeployButton extends HTMLElement {
   constructor() {
     super();
     this.shadow = this.attachShadow({ mode: "open" });
+    this.applyThemeVars();
     this.ctx = nostr.parseContext();
     if (this.ctx) {
       this.manifestPromise = nostr.fetchManifest(this.ctx);
@@ -110,38 +111,57 @@ export class NsiteDeployButton extends HTMLElement {
     }
   }
 
-  attributeChangedCallback() {
+  attributeChangedCallback(name: string) {
+    if (
+      name === "accent" || name === "background" ||
+      name === "text" || name === "radius"
+    ) {
+      this.applyThemeVars();
+    }
     if (this.state === "idle") this.render();
   }
 
-  private get themeVars(): string {
+  private applyThemeVars() {
     const accent = this.getAttribute("accent");
     const background = this.getAttribute("background");
     const text = this.getAttribute("text");
     const radius = this.getAttribute("radius");
 
-    const vars: string[] = [];
+    // Set CSS custom properties directly on the host element.
+    // These persist across shadow.innerHTML rewrites and inherit
+    // into all shadow DOM children via CSS custom property inheritance.
     if (accent) {
-      vars.push(`--steal-this-accent: ${accent};`);
-      vars.push(`--steal-this-accent-hover: color-mix(in srgb, ${accent}, black 15%);`);
+      this.style.setProperty("--steal-this-accent", accent);
+      this.style.setProperty(
+        "--steal-this-accent-hover",
+        `color-mix(in srgb, ${accent}, black 15%)`,
+      );
     }
     if (background) {
-      // Derive input-bg as slightly darker, border as darker still
-      vars.push(`--steal-this-bg: ${background};`);
-      vars.push(`--steal-this-input-bg: color-mix(in srgb, ${background}, black 20%);`);
-      vars.push(`--steal-this-border: color-mix(in srgb, ${background}, black 45%);`);
+      this.style.setProperty("--steal-this-bg", background);
+      this.style.setProperty(
+        "--steal-this-input-bg",
+        `color-mix(in srgb, ${background}, black 20%)`,
+      );
+      this.style.setProperty(
+        "--steal-this-border",
+        `color-mix(in srgb, ${background}, black 45%)`,
+      );
     }
     if (text) {
-      vars.push(`--steal-this-text: ${text};`);
-      vars.push(`--steal-this-muted: color-mix(in srgb, ${text}, transparent 50%);`);
-      vars.push(`--steal-this-dim: color-mix(in srgb, ${text}, transparent 65%);`);
+      this.style.setProperty("--steal-this-text", text);
+      this.style.setProperty(
+        "--steal-this-muted",
+        `color-mix(in srgb, ${text}, transparent 50%)`,
+      );
+      this.style.setProperty(
+        "--steal-this-dim",
+        `color-mix(in srgb, ${text}, transparent 65%)`,
+      );
     }
     if (radius) {
-      vars.push(`--steal-this-radius: ${radius};`);
+      this.style.setProperty("--steal-this-radius", radius);
     }
-
-    if (vars.length === 0) return "";
-    return `:host { ${vars.join(" ")} }`;
   }
 
   private get buttonText(): string {
@@ -166,8 +186,7 @@ export class NsiteDeployButton extends HTMLElement {
 
   private render() {
     this.preserveFormValues();
-    const themeBlock = this.themeVars;
-    let html = `<style>${themeBlock ? themeBlock + "\n" : ""}${STYLES}</style>`;
+    let html = `<style>${STYLES}</style>`;
 
     switch (this.state) {
       case "idle":

--- a/packages/stealthis/src/widget.ts
+++ b/packages/stealthis/src/widget.ts
@@ -32,6 +32,7 @@ export class NsiteDeployButton extends HTMLElement {
     "background",
     "text",
     "radius",
+    "copy-ditto-theme",
   ];
 
   private shadow: ShadowRoot;
@@ -58,6 +59,12 @@ export class NsiteDeployButton extends HTMLElement {
   private muses: nostr.Muse[] = [];
   private museProfiles = new Map<string, nostr.MuseProfile>();
   private musesExpanded = false;
+  private dittoThemePromise: Promise<nostr.DittoTheme | null> | null = null;
+  private _dittoTheme: nostr.DittoTheme | null = null;
+
+  get dittoTheme(): nostr.DittoTheme | null {
+    return this._dittoTheme;
+  }
 
   constructor() {
     super();
@@ -65,6 +72,13 @@ export class NsiteDeployButton extends HTMLElement {
     this.ctx = nostr.parseContext();
     if (this.ctx) {
       this.manifestPromise = nostr.fetchManifest(this.ctx);
+      const dittoNaddr = this.getAttribute("copy-ditto-theme");
+      if (dittoNaddr) {
+        this.dittoThemePromise = nostr.fetchDittoTheme(dittoNaddr).then((theme) => {
+          this._dittoTheme = theme;
+          return theme;
+        });
+      }
       if (!this.hasAttribute("no-trail")) {
         this.manifestPromise.then((manifest) => {
           if (manifest) {


### PR DESCRIPTION
## Summary

- Add `accent`, `background`, `text`, `radius` HTML attributes to `<steal-this>` for declarative theming via CSS custom properties
- Migrate all hardcoded hex values in styles.css to `var(--steal-this-*)` with inline fallback defaults
- Add `copy-ditto-theme` attribute: resolves naddr to kind 36767/16767 Ditto theme event, extracts colors/fonts/background per [Ditto NIP spec](https://github.com/soapbox-pub/ditto/blob/main/NIP.md)
- Add deploy-flow "Copy theme" step: shows resolved theme preview (color swatches, fonts, background), publishes kind 16767 active profile theme to user's write relays with overwrite warning
- When only `accent` is set, modal surfaces (bg, inputs, borders) derive dark shades from accent via `color-mix` for cohesive theming

Closes #24

## Test plan

- [x] Set `accent="#e74c3c"` — button AND modal should show red theme
- [x] Set `background="#2d2d44" accent="#3498db"` — modal surfaces reflect custom bg
- [x] Set `radius="0"` — sharp corners everywhere; `radius="16px"` — rounded
- [x] Set `copy-ditto-theme="naddr1..."` with a valid Ditto theme naddr — verify theme preview step appears after auth
- [ ] Malformed naddr — no crash, deploy proceeds normally
- [ ] "Copy theme" publishes kind 16767 event; "Skip" bypasses